### PR TITLE
OrderType Factory and Seeder created

### DIFF
--- a/database/factories/OrderTypeFactory.php
+++ b/database/factories/OrderTypeFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\OrderType;
+use Faker\Generator as Faker;
+
+$factory->define(OrderType::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+    ];
+});

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,12 +11,13 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-         $this->call(UserSeeder::class);
-         $this->call(ItemCategorySeeder::class);
+        $this->call(UserSeeder::class);
+        $this->call(ItemCategorySeeder::class);
         $this->call(OffersSeeder::class);
         $this->call(OfferItemSeeder::class);
         $this->call(ExtraCategorySeeder::class);
         $this->call(ExtraSeeder::class);
         $this->call(ExtraItemCategorySeeder::class);
+        $this->call(OrderTypeSeeder::class);
     }
 }

--- a/database/seeds/OrderTypeSeeder.php
+++ b/database/seeds/OrderTypeSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class OrderTypeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\OrderType::class, 7)->create();
+    }
+}


### PR DESCRIPTION
Seeder also added to the DatabaseSeeder to create 7 types of orders by default (Primary Key IDs of 1 - 7), when `php artisan db:seed` command executed.