### PR TITLE
OrderStatus Factory and Seeder created

### DIFF
--- a/database/factories/OrderStatusFactory.php
+++ b/database/factories/OrderStatusFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\OrderStatus;
+use Faker\Generator as Faker;
+
+$factory->define(OrderStatus::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+    ];
+});

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -19,5 +19,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ExtraSeeder::class);
         $this->call(ExtraItemCategorySeeder::class);
         $this->call(OrderTypeSeeder::class);
+        $this->call(OrderStatusSeeder::class);
     }
 }

--- a/database/seeds/OrderStatusSeeder.php
+++ b/database/seeds/OrderStatusSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class OrderStatusSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\OrderStatus::class, 5)->create();
+    }
+}


### PR DESCRIPTION
Seeder also added to the DatabaseSeeder to create 5 types of order statuses by default (Primary Key IDs of 1 - 5), when `php artisan db:seed` command executed.